### PR TITLE
Fix .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: python:3.9.0-slim-buster
+image: python:3.9-buster
 
 services:
   - docker:stable-dind

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: python:3.7-buster
+image: python:3.9.0-slim-buster
 
 services:
   - docker:stable-dind
@@ -28,7 +28,7 @@ before_script:
 test:
   script:
     - mkdir -p $TMPDIR
-    - cwltest --verbose --test test.yml --junit-xml=results.xml
+    - cwltest --test test.yml --junit-xml=results.xml
   artifacts:
     reports:
       junit: results.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,7 +26,7 @@ before_script:
 
 test:
   script:
-    - cwltest --test test.yml --junit-xml=results.xml
+    - cwltest --verbose --test test.yml --junit-xml=results.xml
   artifacts:
     reports:
       junit: results.xml

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ services:
 
 variables:
   DOCKER_HOST: tcp://docker:2375/
+  TMPDIR: /builds/$CI_PROJECT_PATH/tmp
 
 before_script:
   - pip install cwl-runner cwltest
@@ -26,6 +27,7 @@ before_script:
 
 test:
   script:
+    - mkdir -p $TMPDIR
     - cwltest --verbose --test test.yml --junit-xml=results.xml
   artifacts:
     reports:


### PR DESCRIPTION
Currently the CI tester on Gitlab fails due to timeout.
This request is to investigate the reason why it fails.
